### PR TITLE
That way, the d.ts files are added, not excluded

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@ demo/
 *.log
 *.map
 *.ts
-!.d.ts
+!*.d.ts


### PR DESCRIPTION
`!.d.ts` This doesn't add any defination file when installed from npm which is quite necessary when working with TYPESCRIPT
