### PR TITLE
Unittest support 🎁

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 !scripts/*.js
 demo/app/*.js
+!demo/app/tests/*.js
 demo/*.d.ts
 demo/lib
 demo/platforms

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ Then use any of the available options from the `tns` command line:
 * [Run your project](https://github.com/NativeScript/nativescript-cli#run-your-project)
 * [Full list of commands](https://github.com/NativeScript/nativescript-cli#the-commands)
 
+## Unittesting
+This plugin automatically adds Jasmine-based unittest support to your plugin.
+Open `demo/app/tests/tests.js` and adjust its contents.
+
+You can read more about this topic [here](https://docs.nativescript.org/tooling/testing).
+
+Once you're ready to test your plugin's API execute one of these commands in the plugin root:
+
+```
+npm run test.ios
+npm run test.android
+```
+
 ## Publish
 
 When you have everything ready to publish:

--- a/demo/app/tests/tests.js
+++ b/demo/app/tests/tests.js
@@ -1,0 +1,13 @@
+var YourPlugin = require("nativescript-yourplugin").YourPlugin;
+var yourPlugin = new YourPlugin();
+
+// TODO replace 'functionname' with an acual function name of your plugin class and run with 'npm test <platform>'
+describe("functionname", function() {
+  it("exists", function() {
+    expect(yourPlugin.functionname).toBeDefined();
+  });
+
+  it("returns a promise", function() {
+    expect(yourPlugin.functionname()).toEqual(jasmine.any(Promise));
+  });
+});

--- a/demo/package.json
+++ b/demo/package.json
@@ -9,6 +9,7 @@
     }
   },
   "dependencies": {
+    "nativescript-unit-test-runner": "^0.3.0",
     "nativescript-yourplugin": "file:..",
     "tns-core-modules": "^2.3.0"
   },
@@ -17,6 +18,10 @@
     "babel-types": "6.11.1",
     "babylon": "6.8.4",
     "filewalker": "0.1.2",
+    "jasmine-core": "^2.5.2",
+    "karma": "^1.3.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-nativescript-launcher": "^0.4.0",
     "lazy": "1.0.11",
     "nativescript-dev-typescript": "^0.3.2",
     "typescript": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "demo.ios": "npm run preparedemo && cd demo && tns emulate ios",
     "demo.ios.device": "npm run preparedemo && cd demo && tns run ios",
     "demo.android": "npm run preparedemo && cd demo && tns run android",
+    "test.ios": "cd demo && tns test ios --emulator",
+    "test.ios.device": "cd demo && tns test ios",
+    "test.android": "cd demo && tns test android",
     "preparedemo": "npm run build && cd demo && tns plugin remove nativescript-yourplugin && tns plugin add .. && tns install",
     "setup": "npm i && cd demo && npm i && cd .. && npm run build && cd demo && tns plugin add .. && cd ..",
     "postclone": "npm i && node scripts/postclone.js"

--- a/scripts/postclone.js
+++ b/scripts/postclone.js
@@ -90,6 +90,8 @@ function adjustScripts() {
       var demoFile = demoFiles[d];
       files.push(demo_folder + "/app/" + demoFile);
     }
+    // add the tests
+    files.push(demo_folder + "/app/tests/tests.js");
 
     // prepare and cache a few Regexp thingies
     var regexp_seed_plugin_name = new RegExp(seed_plugin_name, "g");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "files": [
       "node_modules/tns-core-modules/tns-core-modules.d.ts",
       "node_modules/tns-platform-declarations/tns-core-modules/android17.d.ts",
-      "node_modules/tns-platform-declarations/tns-core-modules/ios.d.ts",
       "node_modules/tns-platform-declarations/tns-core-modules/org.nativescript.widgets.d.ts",
       "yourplugin.common.ts",
       "yourplugin.android.ts", 


### PR DESCRIPTION
It seems like good practice to add (at least very basic) unittests to our plugins. It's even valuable to have a x-plat test that verifies all functions are available on all platforms, and have a similar API. Depending on the plugin the tests can even assert the result.

[Here's a few basic tests](https://github.com/EddyVerbruggen/nativescript-nfc/tree/master/demo/app/tests) to get anyone started with this.

I made the choice to add Jasmine as a fwk but it can be swapped out for Mocha or Qunit as well. I chose Jasmine because it has stuff like asserts built in so no other tools are required.