### PR TITLE
Update package.json to allow webpack bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-yourplugin",
   "version": "1.0.0",
   "description": "Your awesome NativeScript plugin.",
-  "main": "yourplugin.js",
+  "main": "yourplugin",
   "typings": "index.d.ts",
   "nativescript": {
     "platforms": {


### PR DESCRIPTION
We released a new version of the NS webpack plugin [NS webpack plugin](https://github.com/NativeScript/nativescript-dev-webpack) yesterday.  That change is necessary all NativeScript plugins to be compatible with it. The `.js` extension of the `main` property in the `package.json` should be removed. That way, webpack will be able to correctly reference the android or ios main file.

Check out the [Webpack article](http://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) in the NativeScript  documentation. 